### PR TITLE
add log-sum-exp "trick" for numerical stability

### DIFF
--- a/losses.py
+++ b/losses.py
@@ -138,8 +138,10 @@ class NPairLoss(nn.Module):
         positives = torch.unsqueeze(positives, dim=1)  # (n, 1, embedding_size)
 
         x = torch.matmul(anchors, (negatives - positives).transpose(1, 2))  # (n, 1, n-1)
-        x = torch.sum(torch.exp(x), 2)  # (n, 1)
-        loss = torch.mean(torch.log(1+x))
+        # Implements the log-sum-exp trick for numerical stability (see: https://en.wikipedia.org/wiki/LogSumExp)
+        a, _ = torch.max(x, dim=0)
+        x = torch.sum(torch.exp(x - a), 2)  # (n, 1)
+        loss = torch.mean(a + torch.log(1+x))
         return loss
 
     @staticmethod


### PR DESCRIPTION
This PR updates the `n_pair_loss` method so that it uses the [log-sum-exp](https://en.wikipedia.org/wiki/LogSumExp) trick for numerical stability. When I used the `NPairLoss` within my model, I ran into NaN's.

It would be better to use [PyTorch's implementation](https://pytorch.org/docs/stable/torch.html#torch.logsumexp) directly, but I wasn't sure what to do with the 1 + within the log of the loss function, so I rolled my own solution. I tested that it works in my own model.